### PR TITLE
doc: fixed the link to CONTRIBUTING.rst in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,7 @@ Contributing
 ============
 
 Contributions are always welcome! Please read the `contributing guidelines
-<https://github.com/matthiaskoenig/sbmlutils/blob/devel/CONTRIBUTING.rst>`__ to
+<https://github.com/matthiaskoenig/sbmlutils/blob/develop/.github/CONTRIBUTING.rst>`__ to
 get started.
 
 License


### PR DESCRIPTION
* [x] fix #179 
* [x] fixed the link to the contribution guidelines file (```CONTRIBUTING.rst```) in ```README.rst```
