### PR TITLE
Protect develop and main with rulesets and document the branch model

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -7,7 +7,9 @@ search = "{current_version}"
 replace = "{new_version}"
 regex = false
 ignore_missing_version = false
-tag = true
+# no tag: the bump is merged into develop through a pull request, which
+# rewrites the commit, so the tag is created on develop afterwards
+tag = false
 sign_tags = false
 tag_name = "{new_version}"
 tag_message = "Bump version: {current_version} → {new_version}"

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @matthiaskoenig

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+## Summary
+
+<!-- what does this change and why -->
+
+## Checklist
+
+- [ ] the pull request targets `develop`
+- [ ] tests were added or updated for the change
+- [ ] `tox run-parallel` passes locally (tests and `ty`)
+- [ ] `ruff check` and `ruff format` are clean, e.g., via `pre-commit run --all-files`
+- [ ] public functions and classes have type annotations and a docstring
+- [ ] user visible changes are in `release-notes/` and, if needed, in `docs/`

--- a/.github/rulesets/apply.sh
+++ b/.github/rulesets/apply.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# Apply the repository policies of sbmlutils: the merge settings of the
+# repository and the rulesets in this directory. The script is idempotent, i.e.,
+# a ruleset which already exists is updated instead of added a second time, so
+# it can be run again after every change of the json files.
+#
+# The file name of a ruleset has to match the "name" in the json. A ruleset which
+# is removed from this directory stays on the repository, delete it with
+# `gh api -X DELETE repos/<owner>/<repo>/rulesets/<id>`.
+#
+# Requires the github cli (https://cli.github.com) authenticated as a user with
+# admin permission on the repository:
+#
+#   gh auth login
+#   .github/rulesets/apply.sh [owner/repo]
+#
+set -euo pipefail
+
+REPO="${1:-matthiaskoenig/sbmlutils}"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "repository settings of ${REPO}"
+gh api -X PATCH "repos/${REPO}" \
+  -F allow_auto_merge=true \
+  -F delete_branch_on_merge=true \
+  -F allow_update_branch=true \
+  -F allow_squash_merge=true \
+  -F allow_rebase_merge=true \
+  -F allow_merge_commit=false \
+  --silent
+
+for path in "${DIR}"/*.json; do
+  name="$(basename "${path}" .json)"
+  id="$(gh api "repos/${REPO}/rulesets" --jq "map(select(.name == \"${name}\")) | .[0].id // empty")"
+  if [[ -n "${id}" ]]; then
+    gh api -X PUT "repos/${REPO}/rulesets/${id}" --input "${path}" --silent
+    echo "ruleset ${name} updated (${id})"
+  else
+    id="$(gh api -X POST "repos/${REPO}/rulesets" --input "${path}" --jq .id)"
+    echo "ruleset ${name} created (${id})"
+  fi
+done

--- a/.github/rulesets/develop.json
+++ b/.github/rulesets/develop.json
@@ -1,0 +1,61 @@
+{
+  "name": "develop",
+  "target": "branch",
+  "enforcement": "active",
+  "bypass_actors": [],
+  "conditions": {
+    "ref_name": {
+      "include": [
+        "refs/heads/develop"
+      ],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "required_linear_history"
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": true,
+        "allowed_merge_methods": [
+          "squash",
+          "rebase"
+        ],
+        "require_extra_approval_for_unattributed_changes": false
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": false,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          {
+            "context": "tests"
+          },
+          {
+            "context": "ruff"
+          },
+          {
+            "context": "ty"
+          },
+          {
+            "context": "docs"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -1,0 +1,17 @@
+{
+  "name": "main",
+  "target": "branch",
+  "enforcement": "active",
+  "bypass_actors": [],
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/main"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {"type": "deletion"},
+    {"type": "non_fast_forward"},
+    {"type": "required_linear_history"}
+  ]
+}

--- a/.github/rulesets/tags.json
+++ b/.github/rulesets/tags.json
@@ -1,0 +1,16 @@
+{
+  "name": "tags",
+  "target": "tag",
+  "enforcement": "active",
+  "bypass_actors": [],
+  "conditions": {
+    "ref_name": {
+      "include": ["~ALL"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {"type": "deletion"},
+    {"type": "non_fast_forward"}
+  ]
+}

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -2,14 +2,19 @@ name: CI-CD
 
 on:
   push:
+    # feature branches are tested through their pull request, tags release
+    branches: [develop, main]
+    tags: ['*']
+  pull_request:
+    branches: [develop, main]
   workflow_dispatch:
 
-# least privilege by default, the release job raises what it needs
+# least privilege by default, the release and sync jobs raise what they need
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   # superseded branch runs are cancelled, release runs are never cancelled
   cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
 
@@ -61,8 +66,24 @@ jobs:
       run:
         uvx --with tox-uv tox -e py${{ matrix.python-version }}
 
-  release:
+  tests:
+    # the one check the branch protection requires; the names of the matrix
+    # jobs change with the matrix, this name does not
+    name: tests
     needs: test
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+    - name: Check the result of the test matrix
+      env:
+        RESULT: ${{ needs.test.result }}
+      run: |
+        echo "test matrix: $RESULT"
+        test "$RESULT" = "success"
+
+  release:
+    needs: tests
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -95,3 +116,20 @@ jobs:
         body_path: "release-notes/${{ github.ref_name }}.md"
         draft: false
         prerelease: false
+
+  sync-main:
+    # main tracks the latest published release, see docs/development.md
+    needs: release
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write  # fast-forward main to the released commit
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        # a shallow clone cannot be pushed to another branch
+        fetch-depth: 0
+    - name: Fast-forward main to the release
+      # no --force: the push fails loudly if it would not be a fast-forward
+      run: git push origin HEAD:main

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,18 +2,24 @@ name: documentation
 
 on:
   push:
+    # feature branches are built through their pull request
+    branches: [develop, main]
+  pull_request:
+    branches: [develop, main]
   workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   # never cancel a running deployment, it would leave the site half published
-  group: pages
   cancel-in-progress: false
 
 jobs:
-  build:
+  docs:
+    # required by the branch protection, see .github/rulesets/develop.json
+    name: docs
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -42,7 +48,7 @@ jobs:
           path: site
 
   deploy:
-    needs: build
+    needs: docs
     # only the default branch publishes to https://matthiaskoenig.github.io/sbmlutils
     if: github.ref == 'refs/heads/develop'
     runs-on: ubuntu-latest

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -2,17 +2,23 @@ name: ruff
 
 on:
   push:
+    # feature branches are checked through their pull request
+    branches: [develop, main]
+  pull_request:
+    branches: [develop, main]
   workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   ruff:
+    # required by the branch protection, see .github/rulesets/develop.json
+    name: ruff
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/ty.yml
+++ b/.github/workflows/ty.yml
@@ -2,17 +2,23 @@ name: ty
 
 on:
   push:
+    # feature branches are checked through their pull request
+    branches: [develop, main]
+  pull_request:
+    branches: [develop, main]
   workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   ty:
+    # required by the branch protection, see .github/rulesets/develop.json
+    name: ty
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,9 @@ python -m examples.species
 python -m examples.tutorial.minimal_model
 ```
 
-Release steps are in `docs/development.md` (there is no separate `RELEASE.md`); version bumps go through `uvx bump-my-version bump [major|minor|patch]` (updates `src/sbmlutils/__init__.py` and `CITATION.cff`), and pushing the tag triggers the PyPI release workflow.
+`develop` is the default branch and takes every change through a pull request; direct pushes are rejected by the rulesets in `.github/rulesets/` (applied with `.github/rulesets/apply.sh`), which require the `tests`, `ruff`, `ty` and `docs` checks. `main` only tracks the latest release and is fast-forwarded by the `sync-main` job of the release workflow, never by hand.
+
+Release steps are in `docs/development.md` (there is no separate `RELEASE.md`): the release is prepared on a branch, `uvx bump-my-version bump [major|minor|patch]` updates `src/sbmlutils/__init__.py` and `CITATION.cff` and commits without tagging (`tag = false`, a squash merge would rewrite the commit), and the tag is created on `develop` after the pull request was merged, which triggers the PyPI release workflow.
 
 Documentation is [Zensical](https://zensical.org/): markdown sources in `docs/`, configured in `zensical.toml`, built into the gitignored `site/` (`uv run zensical build --clean`, `uv run zensical serve` for the preview). The API reference is rendered from the docstrings by mkdocstrings; a page in `docs/api/` is just `::: sbmlutils.<module>`, so nothing is generated into the repository. `scripts/llms_txt.py` runs after the build and writes the agent facing files (`llms.txt`, `llms-full.txt` and the markdown of every page) into `site/`. The `documentation` workflow runs both and publishes the site from `develop`.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -2,6 +2,57 @@
 
 Contributions are welcome. The repository is [matthiaskoenig/sbmlutils](https://github.com/matthiaskoenig/sbmlutils); development happens against the `develop` branch via pull requests.
 
+## Branch model
+
+Two branches are permanent:
+
+- **`develop`** is the default branch and the branch everything is integrated into. The documentation on [matthiaskoenig.github.io/sbmlutils](https://matthiaskoenig.github.io/sbmlutils) is published from it.
+- **`main`** tracks the latest published release. It is fast-forwarded to the released commit by the `sync-main` job of the `CI-CD` workflow after the package went to pypi, so `main` and the newest version on pypi always agree. Nothing is developed on `main` and nothing is merged into it by hand.
+
+Work happens on short lived branches off `develop`, which GitHub deletes after the merge. Releases are tagged on `develop`, see [Release](#release).
+
+## Pull requests
+
+Neither branch accepts a direct push, every change goes through a pull request against `develop`. This includes the maintainer, there is no bypass.
+
+A pull request can only be merged once the four required checks are green:
+
+| check   | workflow      | content                                                              |
+| ------- | ------------- | -------------------------------------------------------------------- |
+| `tests` | `ci-cd.yml`   | the test matrix, linux, macos and windows with python 3.11 to 3.14    |
+| `ruff`  | `ruff.yml`    | `ruff check` and `ruff format --check`                                |
+| `ty`    | `ty.yml`      | `tox r -e ty`                                                         |
+| `docs`  | `docs.yml`    | the zensical build including the api reference and the agent files    |
+
+`tests` aggregates the test matrix into a single job, so the name of the required check stays the same when the matrix changes.
+
+Further rules of a pull request:
+
+- conversations have to be resolved before the merge
+- an approval is dismissed when new commits are pushed
+- the history stays linear, i.e., a pull request is merged with squash or rebase; merge commits are disabled
+- the maintainer is the code owner of the repository (`.github/CODEOWNERS`) and is requested for review on every pull request. A pull request of a contributor is therefore reviewed and merged by the maintainer, who has the only write access. The rulesets themselves do not require an approval: on a personal repository a ruleset cannot ask for an approval only from somebody else, and requiring one would block the pull requests of the maintainer, who cannot approve their own. Once a second person has write access, a ruleset requiring an approving review of a code owner can be added
+
+[Auto-merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/automatically-merging-a-pull-request) is enabled for the repository, so a pull request can be queued and is merged as soon as the checks pass and the required approval is there.
+
+### Repository policies { #repository-policies }
+
+The protection is implemented with [repository rulesets](https://docs.github.com/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets). They are part of the repository in `.github/rulesets/` instead of only living in the web interface, so a change to a policy is reviewed like any other change:
+
+| ruleset                 | applies to | rules                                                                                                                                       |
+| ----------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `develop.json`          | `develop`  | pull request required, the four checks above, resolved conversations, linear history, no force push, no deletion. **No bypass, for anybody.** |
+| `main.json`             | `main`     | linear history, no force push, no deletion, no bypass. The fast-forward of the release workflow needs none, only a force push or a merge commit would be rejected |
+| `tags.json`             | all tags   | a tag cannot be deleted or moved, so a release tag keeps pointing at what was released                                                       |
+
+Changing a policy means changing the json and applying it:
+
+```bash
+.github/rulesets/apply.sh
+```
+
+The script is idempotent: it updates the rulesets which exist and creates the missing ones. It also sets the merge settings of the repository, i.e., auto-merge, delete branch on merge, and squash and rebase as the only merge methods. It needs the [github cli](https://cli.github.com) authenticated as a user with admin permission on the repository.
+
 ## Setup development environment
 
 Development needs [uv](https://docs.astral.sh/uv/) and a checkout of the repository:
@@ -148,18 +199,30 @@ The `documentation` workflow runs both steps, so the files are regenerated with 
 
 ## Release
 
-A release is made from `develop`:
+A release is made from `develop`. Since `develop` only accepts pull requests, the release is prepared on a branch and tagged once that pull request is merged:
 
-1. write the release notes for the version in `release-notes/`
-2. make sure everything passes: `tox run-parallel`, `ruff check`, `tox r -e ty`
-3. check the version bump: `uvx bump-my-version bump [major|minor|patch] --dry-run -vv`
-4. bump the version: `uvx bump-my-version bump [major|minor|patch]`, which updates `src/sbmlutils/__init__.py` and `CITATION.cff`, commits and tags
-5. `git push --tags`, which triggers the release workflow publishing to [pypi](https://pypi.org/project/sbmlutils/), followed by `git push`
-6. test the installation from pypi in a fresh environment:
+1. branch off `develop`: `git switch -c release/x.y.z develop`
+2. write the release notes for the version in `release-notes/x.y.z.md`
+3. make sure everything passes: `tox run-parallel`, `ruff check`, `tox r -e ty`
+4. check the version bump: `uvx bump-my-version bump [major|minor|patch] --dry-run -vv`
+5. bump the version: `uvx bump-my-version bump [major|minor|patch]`, which updates `src/sbmlutils/__init__.py` and `CITATION.cff` and commits. It does not create the tag; a squash or rebase merge would rewrite the commit and leave the tag behind on a commit which is not part of `develop`
+6. push the branch, open the pull request against `develop` and merge it once the checks are green
+7. tag the merged commit on `develop` and push the tag:
+
+    ```bash
+    git switch develop
+    git pull
+    git tag x.y.z
+    git push origin x.y.z
+    ```
+
+    This starts the `CI-CD` workflow, which runs the test matrix, publishes to [pypi](https://pypi.org/project/sbmlutils/), creates the GitHub release from `release-notes/x.y.z.md` and fast-forwards `main` to the tagged commit. Check the version before pushing, a tag cannot be moved or deleted afterwards.
+
+8. test the installation from pypi in a fresh environment:
 
     ```bash
     uv venv --python 3.14
     uv pip install sbmlutils
     ```
 
-7. once Zenodo has archived the release, update the citation information, i.e., `date-released` in `CITATION.cff` and the version, date and version DOI of the release in the citation of `README.md` and `docs/index.md`. `bump-my-version` only updates the version, not the date and the DOI, which are only known after the release
+9. once Zenodo has archived the release, update the citation information, i.e., `date-released` in `CITATION.cff` and the version, date and version DOI of the release in the citation of `README.md` and `docs/index.md`. `bump-my-version` only updates the version, not the date and the DOI, which are only known after the release. These changes go in through a pull request like everything else

--- a/release-notes/0.10.2.md
+++ b/release-notes/0.10.2.md
@@ -1,0 +1,13 @@
+# Release notes for sbmlutils 0.10.2
+![sbmlutils](https://github.com/matthiaskoenig/sbmlutils/raw/develop/docs/images/sbmlutils-logo-60.png)
+
+We are pleased to release the next version of sbmlutils including the following changes.
+
+## Development
+- every change goes into `develop` through a pull request; the tests, `ruff`, `ty` and the documentation build have to pass before a merge is possible
+- `main` tracks the latest published release and is fast-forwarded to the released commit by the release workflow instead of being merged by hand; it was reset once to the 0.10.1 release for this, which dropped the merge commits it carried
+- the workflows also run on pull requests, so contributions from forks are tested
+- the branch protection is part of the repository as rulesets in `.github/rulesets/`, together with `CODEOWNERS` and a pull request template
+- the branch model, the pull request rules and the adjusted release process are documented in `docs/development.md`
+
+Your sbmlutils team


### PR DESCRIPTION
Applies the branch model of [pymetadata#74](https://github.com/matthiaskoenig/pymetadata/pull/74)/[#75](https://github.com/matthiaskoenig/pymetadata/pull/75) and [libsbgnpy#83](https://github.com/matthiaskoenig/libsbgnpy/pull/83) to sbmlutils.

Every change goes into `develop` through a pull request; the tests, `ruff`, `ty` and the documentation build are required and there is no bypass, also not for the maintainer. `main` tracks the latest published release and is fast-forwarded by the release workflow instead of being merged by hand.

- the workflows run on pull requests, so contributions from forks are tested
- an aggregating `tests` job keeps the name of the required check stable when the test matrix changes
- `sync-main` fast-forwards `main` to the tagged commit after the pypi release
- the rulesets are checked in under `.github/rulesets/` and applied with `.github/rulesets/apply.sh`, together with `CODEOWNERS` and a pull request template
- bump-my-version no longer tags, since the release pull request rewrites the commit; the tag is created on `develop` after the merge

After this is merged, `main` is reset once to the 0.10.1 release (it carries five `Merge pull request ... from develop` commits which are not on `develop` and no unique content, so `sync-main` could never fast-forward it) and `.github/rulesets/apply.sh` is run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Hf7vM5Aj5Kc7yt9njsJGS