### PR TITLE
Release 0.10.2

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.10.1"
+current_version = "0.10.2"
 commit = true
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,8 @@ dependencies = [
 	"pymetadata>=0.6.2",
 	"python-libsbml>=5.21.1",
 	"antimony>=3.1.3",
+	# the win_amd64 wheel of antimony 3.2.0 raises a C++ exception in loadAntimonyString
+	"antimony!=3.2.0; sys_platform == 'win32'",
 	# data structures, units and output
 	"pydantic>=2.13.5",
 	"pint>=0.25.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,9 +37,9 @@ keywords = [
 ]
 dependencies = [
 	# SBML
+	"pymetadata>=0.6.2",
 	"python-libsbml>=5.21.1",
 	"antimony>=3.1.3",
-	"pymetadata>=0.6.1",
 	# data structures, units and output
 	"pydantic>=2.13.5",
 	"pint>=0.25.3",
@@ -79,7 +79,7 @@ dev = [
 	"tox>=4.61.2",
 	"pytest>=9.1.1",
 	"pytest-cov>=7.1.0",
-	"zensical>=0.0.59",
+	"zensical>=0.0.60",
 	"mkdocstrings-python>=2.0.8",
 ]
 

--- a/release-notes/0.10.2.md
+++ b/release-notes/0.10.2.md
@@ -4,10 +4,7 @@
 We are pleased to release the next version of sbmlutils including the following changes.
 
 ## Development
-- every change goes into `develop` through a pull request; the tests, `ruff`, `ty` and the documentation build have to pass before a merge is possible
-- `main` tracks the latest published release and is fast-forwarded to the released commit by the release workflow instead of being merged by hand; it was reset once to the 0.10.1 release for this, which dropped the merge commits it carried
-- the workflows also run on pull requests, so contributions from forks are tested
-- the branch protection is part of the repository as rulesets in `.github/rulesets/`, together with `CODEOWNERS` and a pull request template
-- the branch model, the pull request rules and the adjusted release process are documented in `docs/development.md`
+- pymetadata >= 0.6.2 is required, which adds `EntryFormat.ANTIMONY` for antimony model files in COMBINE archives
+- zensical >= 0.0.60 is required; the mkdocstrings options in `zensical.toml` are set on the plugin table directly, the `config` table is no longer accepted
 
 Your sbmlutils team

--- a/release-notes/0.10.2.md
+++ b/release-notes/0.10.2.md
@@ -3,6 +3,9 @@
 
 We are pleased to release the next version of sbmlutils including the following changes.
 
+## Fixes
+- antimony 3.2.0 is excluded on Windows: its wheel raises `OSError: [WinError -529697949] Windows Error 0xe06d7363` in `loadAntimonyString` when parsing the antimony of the repressilator model, which breaks `antimony_to_sbml`. Linux and macOS are not affected
+
 ## Development
 - pymetadata >= 0.6.2 is required, which adds `EntryFormat.ANTIMONY` for antimony model files in COMBINE archives
 - zensical >= 0.0.60 is required; the mkdocstrings options in `zensical.toml` are set on the plugin table directly, the `config` table is no longer accepted

--- a/src/sbmlutils/__init__.py
+++ b/src/sbmlutils/__init__.py
@@ -7,7 +7,7 @@ from pathlib import Path
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 __author__ = "Matthias König"
-__version__ = "0.10.1"
+__version__ = "0.10.2"
 
 
 program_name = "sbmlutils"

--- a/zensical.toml
+++ b/zensical.toml
@@ -134,13 +134,13 @@ icon = "fontawesome/brands/python"
 link = "https://pypi.org/project/sbmlutils/"
 
 # API reference is rendered from the docstrings, see the `docs/api` pages
-[project.plugins.mkdocstrings.config]
+[project.plugins.mkdocstrings]
 default_handler = "python"
 
-[project.plugins.mkdocstrings.config.handlers.python]
+[project.plugins.mkdocstrings.handlers.python]
 paths = ["src"]
 
-[project.plugins.mkdocstrings.config.handlers.python.options]
+[project.plugins.mkdocstrings.handlers.python.options]
 docstring_style = "google"
 docstring_section_style = "table"
 show_source = false


### PR DESCRIPTION
Release 0.10.2: pymetadata >= 0.6.2 and zensical >= 0.0.60.

- `pyproject.toml`: pymetadata >= 0.6.2, zensical >= 0.0.60
- `zensical.toml`: the mkdocstrings options are set on the plugin table directly, zensical 0.0.60 rejects the `config` table (`unknown mkdocstrings option: config`)
- `release-notes/0.10.2.md`
- version bump to 0.10.2 in `src/sbmlutils/__init__.py` only; `CITATION.cff` keeps the 0.10.0 Zenodo record since Zenodo is currently not working

After the merge the tag `0.10.2` is created on `develop`, which triggers the PyPI release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QBzahedfz2qsfcXoeDyKdx